### PR TITLE
support for PascalCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ Using this plugin with SSR could result in larger payload due to the extra attri
 #### attribute : (string)
 The attribute name to be used instead of `data-qa`.
 #### format : (string)
-**Support values:** `kebab`, `camel`, `snake` \
+**Support values:** `kebab`, `camel`, `snake`, `pascal` \
 **Default value:** `kebab`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Using this plugin with SSR could result in larger payload due to the extra attri
     "env": {
         "dev": {
             plugins: [
-                ["babel-transform-react-styled-components-qa", {
+                ["transform-react-styled-components-qa", {
                     "attribute": "data-qa",
                     "format": "kebab"
                 }]

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -240,6 +240,86 @@ const RandomName = styled[tag].attrs(props => {
 "
 `;
 
+exports[`format pascal 1. babel-plugin-transform-react-styled-components-qa: 1. babel-plugin-transform-react-styled-components-qa 1`] = `
+"
+/* eslint-disable */
+
+// without attrs at ( standard html tags )
+const AwesomeComponent = styled.div\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with attrs ( standard html tags )
+const RockyMountain = styled.div.attrs({
+	underlined: true,
+	accentColor: 'red',
+})\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// without attrs ( computed tag )
+const CoverImage = styled[tag]\`
+	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with attrs ( computed tag )
+const RandomName = styled[tag].attrs({
+	underlined: true,
+	accentColor: 'blue',
+})\`
+	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+/* eslint-disable */
+// without attrs at ( standard html tags )
+const AwesomeComponent = styled.div.attrs(props => {
+  return {
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"AwesomeComponent\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with attrs ( standard html tags )
+
+const RockyMountain = styled.div.attrs(props => {
+  return {
+    underlined: true,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"RockyMountain\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // without attrs ( computed tag )
+
+const CoverImage = styled[tag].attrs(props => {
+  return {
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"CoverImage\\"
+  };
+})\`
+	width: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with attrs ( computed tag )
+
+const RandomName = styled[tag].attrs(props => {
+  return {
+    underlined: true,
+    accentColor: 'blue',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"RandomName\\"
+  };
+})\`
+	width: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`;
+"
+`;
+
 exports[`format snake 1. babel-plugin-transform-react-styled-components-qa: 1. babel-plugin-transform-react-styled-components-qa 1`] = `
 "
 /* eslint-disable */

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -46,6 +46,14 @@ pluginTester({
 
 pluginTester({
 	...common,
+	title: 'format pascal',
+	pluginOptions: {
+		format: 'pascal',
+	},
+})
+
+pluginTester({
+	...common,
 	title: 'custom attrubute',
 	pluginOptions: {
 		attribute: 'data-wn-qa',

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,25 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = _default;
 
-exports.default = function ({ types: t }) {
+var _options = require("./options");
+
+var babelType = _interopRequireWildcard(require("@babel/types"));
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+/**
+ *
+ * @param {{ types: typeof babelType }}
+ */
+function _default({
+  types: t
+}) {
   return {
     visitor: {
       VariableDeclarator(path, state) {
@@ -15,28 +30,29 @@ exports.default = function ({ types: t }) {
         }
 
         const format = (0, _options.getComponentNameFormatter)(state.opts);
-        const attributeName = (0, _options.getAttributeName)(state.opts);
+        const attributeName = (0, _options.getAttributeName)(state.opts); // tag part of the template literal
 
-        // tag part of the template literal
-        const tag = init.tag;
+        const tag = init.tag; // styled.div , styled.p , styled[<computed_value>], etc
 
-        // styled.div , styled.p , styled[<computed_value>], etc
         if (t.isMemberExpression(tag)) {
-          const { object, property } = tag;
+          const {
+            object,
+            property
+          } = tag;
+
           if (object.name === 'styled') {
-            init.tag = t.callExpression(t.memberExpression(t.memberExpression(object, property, tag.computed), t.identifier('attrs')), [t.objectExpression([t.objectProperty(t.stringLiteral(attributeName), t.stringLiteral(format(path.node.id.name)))])]);
+            init.tag = t.callExpression(t.memberExpression(t.memberExpression(object, property, tag.computed), t.identifier('attrs')), [t.arrowFunctionExpression([t.identifier('props')], t.blockStatement([t.returnStatement(t.objectExpression([t.objectProperty(t.stringLiteral(attributeName), t.logicalExpression('||', t.memberExpression(t.identifier('props'), t.stringLiteral(attributeName), true), t.stringLiteral(format(path.node.id.name))))]))]))]);
           }
         }
 
         if (t.isCallExpression(tag)) {
           // styled.div.attrs({}) or styled[tag].attrs({})
           if (t.isMemberExpression(tag.callee) && t.isIdentifier(tag.callee.property) && tag.callee.property.name === 'attrs' && t.isMemberExpression(tag.callee.object) && t.isIdentifier(tag.callee.object.object) && tag.callee.object.object.name === 'styled') {
-            tag.arguments = [t.objectExpression(tag.arguments[0].properties.concat(t.objectProperty(t.stringLiteral(attributeName), t.stringLiteral(format(path.node.id.name)))))];
+            tag.arguments = [t.arrowFunctionExpression([t.identifier('props')], t.blockStatement([t.returnStatement(t.objectExpression(tag.arguments[0].properties.concat(t.objectProperty(t.stringLiteral(attributeName), t.logicalExpression('||', t.memberExpression(t.identifier('props'), t.stringLiteral(attributeName), true), t.stringLiteral(format(path.node.id.name)))))))]))];
           }
         }
       }
+
     }
   };
-};
-
-var _options = require('./options');
+}

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,34 +1,34 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getComponentNameFormatter = exports.getAttributeName = undefined;
+exports.getComponentNameFormatter = exports.getAttributeName = void 0;
 
-var _lodash = require('lodash.isstring');
+var _lodash = _interopRequireDefault(require("lodash.isstring"));
 
-var _lodash2 = _interopRequireDefault(_lodash);
+var _lodash2 = _interopRequireDefault(require("lodash.camelcase"));
 
-var _lodash3 = require('lodash.camelcase');
+var _lodash3 = _interopRequireDefault(require("lodash.kebabcase"));
 
-var _lodash4 = _interopRequireDefault(_lodash3);
+var _lodash4 = _interopRequireDefault(require("lodash.snakecase"));
 
-var _lodash5 = require('lodash.kebabcase');
-
-var _lodash6 = _interopRequireDefault(_lodash5);
-
-var _lodash7 = require('lodash.snakecase');
-
-var _lodash8 = _interopRequireDefault(_lodash7);
+var _lodash5 = _interopRequireDefault(require("lodash.upperfirst"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const getAttributeName = exports.getAttributeName = opts => (0, _lodash2.default)(opts.attribute) ? opts.attribute : 'data-qa';
+const pascalCase = s => (0, _lodash5.default)((0, _lodash2.default)(s));
 
+const getAttributeName = opts => (0, _lodash.default)(opts.attribute) ? opts.attribute : 'data-qa';
+
+exports.getAttributeName = getAttributeName;
 const formattersByName = {
-  camel: _lodash4.default,
-  kebab: _lodash6.default,
-  snake: _lodash8.default
+  camel: _lodash2.default,
+  kebab: _lodash3.default,
+  snake: _lodash4.default,
+  pascal: pascalCase
 };
 
-const getComponentNameFormatter = exports.getComponentNameFormatter = opts => (0, _lodash2.default)(opts.format) && opts.format in formattersByName ? formattersByName[opts.format] : _lodash6.default;
+const getComponentNameFormatter = opts => (0, _lodash.default)(opts.format) && opts.format in formattersByName ? formattersByName[opts.format] : _lodash3.default;
+
+exports.getComponentNameFormatter = getComponentNameFormatter;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"lodash.camelcase": "^4.3.0",
 		"lodash.isstring": "^4.0.1",
 		"lodash.kebabcase": "^4.1.1",
-		"lodash.snakecase": "^4.1.1"
+		"lodash.snakecase": "^4.1.1",
+		"lodash.upperfirst": "4.3.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-transform-react-styled-components-qa",
-	"version": "1.0.3",
+	"version": "2.0.1",
 	"description": "Add data-qa property to styled-components via .attrs using the component name",
 	"main": "lib/index.js",
 	"scripts": {

--- a/src/options.js
+++ b/src/options.js
@@ -2,6 +2,9 @@ import isString from 'lodash.isstring'
 import camelCase from 'lodash.camelcase'
 import kebabCase from 'lodash.kebabcase'
 import snakeCase from 'lodash.snakecase'
+import upperFirst from 'lodash.upperfirst'
+
+const pascalCase = s => upperFirst(camelCase(s))
 
 export const getAttributeName = opts =>
 	isString(opts.attribute) ? opts.attribute : 'data-qa'
@@ -10,6 +13,7 @@ const formattersByName = {
 	camel: camelCase,
 	kebab: kebabCase,
 	snake: snakeCase,
+	pascal: pascalCase,
 }
 
 export const getComponentNameFormatter = opts =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,6 +3369,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.upperfirst@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
+
 lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"


### PR DESCRIPTION
[babel-plugin-transform-react-qa-classes](https://github.com/davesnx/babel-plugin-transform-react-qa-classes) has support for pascal case.

I also want to use pascal case.

changes bellow

* add support for pascal case
* fix .babelrc example at README
* fix package.json version.  
 latest released version is 2.0.0 but package.json version is 1.0.3
