### PR TITLE
Add support for props in attrs

### DIFF
--- a/__tests__/__fixtures__/code
+++ b/__tests__/__fixtures__/code
@@ -29,3 +29,23 @@ const RandomName = styled[tag].attrs({
 	width: 12px;
 	border-bottom: ${props => (props.underlined ? '1px solid' : none)};
 `
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))`
+	font-size: 12px;
+	border-bottom: ${props => (props.underlined ? '1px solid' : none)};
+`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})`
+	font-size: 12px;
+	border-bottom: ${props => (props.underlined ? '1px solid' : none)};
+`

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -34,6 +34,26 @@ const RandomName = styled[tag].attrs({
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 /* eslint-disable */
@@ -76,6 +96,26 @@ const RandomName = styled[tag].attrs(props => {
 })\`
 	width: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-wn-qa\\": props[\\"data-wn-qa\\"] || \\"dynamic-attrs-object\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-wn-qa\\": props[\\"data-wn-qa\\"] || \\"dynamic-attrs-block\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "
 `;
@@ -111,6 +151,26 @@ const RandomName = styled[tag].attrs({
 	accentColor: 'blue',
 })\`
 	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
@@ -156,6 +216,26 @@ const RandomName = styled[tag].attrs(props => {
 })\`
 	width: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamicAttrsObject\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamicAttrsBlock\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "
 `;
@@ -191,6 +271,26 @@ const RandomName = styled[tag].attrs({
 	accentColor: 'blue',
 })\`
 	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
@@ -236,6 +336,26 @@ const RandomName = styled[tag].attrs(props => {
 })\`
 	width: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic-attrs-object\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic-attrs-block\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "
 `;
@@ -271,6 +391,26 @@ const RandomName = styled[tag].attrs({
 	accentColor: 'blue',
 })\`
 	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
@@ -316,6 +456,26 @@ const RandomName = styled[tag].attrs(props => {
 })\`
 	width: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-qa\\": props[\\"data-qa\\"] || \\"DynamicAttrsObject\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"DynamicAttrsBlock\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "
 `;
@@ -351,6 +511,26 @@ const RandomName = styled[tag].attrs({
 	accentColor: 'blue',
 })\`
 	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
@@ -396,6 +576,26 @@ const RandomName = styled[tag].attrs(props => {
 })\`
 	width: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic_attrs_object\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic_attrs_block\\"
+  };
+})\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "
 `;
@@ -431,6 +631,26 @@ const RandomName = styled[tag].attrs({
 	accentColor: 'blue',
 })\`
 	width: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsObject = styled.div.attrs(props => ({
+	underlined: props.underlined,
+	accentColor: 'red',
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
+\`
+
+// with dynamic attrs ( standard html tags )
+const DynamicAttrsBlock = styled.div.attrs(props => {
+    return {
+        underlined: props.underlined,
+        accentColor: 'red',
+    }
+})\`
+	font-size: 12px;
 	border-bottom: \${props => (props.underlined ? '1px solid' : none)};
 \`
 
@@ -475,6 +695,26 @@ const RandomName = styled[tag].attrs(props => {
   };
 })\`
 	width: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsObject = styled.div.attrs(props => ({
+  underlined: props.underlined,
+  accentColor: 'red',
+  \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic-attrs-object\\"
+}))\`
+	font-size: 12px;
+	border-bottom: \${props => props.underlined ? '1px solid' : none};
+\`; // with dynamic attrs ( standard html tags )
+
+const DynamicAttrsBlock = styled.div.attrs(props => {
+  return {
+    underlined: props.underlined,
+    accentColor: 'red',
+    \\"data-qa\\": props[\\"data-qa\\"] || \\"dynamic-attrs-block\\"
+  };
+})\`
+	font-size: 12px;
 	border-bottom: \${props => props.underlined ? '1px solid' : none};
 \`;
 "

--- a/src/index.js
+++ b/src/index.js
@@ -70,11 +70,30 @@ export default function({ types: t }) {
 						const argument = tag.arguments[0]
 						const newProperty = t.objectProperty(
 							t.stringLiteral(attributeName),
-							t.stringLiteral(format(path.node.id.name))
+							t.logicalExpression(
+								'||',
+								t.memberExpression(
+									t.identifier('props'),
+									t.stringLiteral(attributeName),
+									true,
+								),
+								t.stringLiteral(format(path.node.id.name)),
+							),
 						)
 						switch (true) {
 							case t.isObjectExpression(argument): {
-								argument.properties.push(newProperty)
+								tag.arguments = [
+									t.arrowFunctionExpression(
+										[t.identifier('props')],
+										t.blockStatement([
+											t.returnStatement(
+												t.objectExpression(
+													tag.arguments[0].properties.concat(newProperty),
+												),
+											),
+										]),
+									),
+								]
 								break
 							}
 							case t.isArrowFunctionExpression(argument):

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function({ types: t }) {
 					}
 				}
 				if (t.isCallExpression(tag)) {
-					// styled.div.attrs({}) or styled[tag].attrs({})
+					// styled.div.attrs({}), styled.div.attrs(props => ({})), styled[tag].attrs({})
 					if (
 						t.isMemberExpression(tag.callee) &&
 						t.isIdentifier(tag.callee.property) &&
@@ -67,31 +67,34 @@ export default function({ types: t }) {
 						t.isIdentifier(tag.callee.object.object) &&
 						tag.callee.object.object.name === 'styled'
 					) {
-						tag.arguments = [
-							t.arrowFunctionExpression(
-								[t.identifier('props')],
-								t.blockStatement([
-									t.returnStatement(
-										t.objectExpression(
-											tag.arguments[0].properties.concat(
-												t.objectProperty(
-													t.stringLiteral(attributeName),
-													t.logicalExpression(
-														'||',
-														t.memberExpression(
-															t.identifier('props'),
-															t.stringLiteral(attributeName),
-															true,
-														),
-														t.stringLiteral(format(path.node.id.name)),
-													),
-												),
-											),
-										),
-									),
-								]),
-							),
-						]
+						const argument = tag.arguments[0]
+						const newProperty = t.objectProperty(
+							t.stringLiteral(attributeName),
+							t.stringLiteral(format(path.node.id.name))
+						)
+						switch (true) {
+							case t.isObjectExpression(argument): {
+								argument.properties.push(newProperty)
+								break
+							}
+							case t.isArrowFunctionExpression(argument):
+							case t.isFunctionExpression(argument): {
+								const { body } = argument
+								switch (true) {
+									case t.isBlockStatement(body): {
+										const ret = body.body.find((path) => t.isReturnStatement(path))
+										if (ret) {
+											ret.argument.properties.push(newProperty)
+										}
+										break
+									}
+									case t.isObjectExpression(body): {
+										body.properties.push(newProperty)
+										break
+									}
+								}
+							}
+						}
 					}
 				}
 			},


### PR DESCRIPTION
Adds support for [documented behavior](https://styled-components.com/docs/api#attrs).

I might not have hit every possible scenario, but I think I got the most common ones.
```
.attrs(props => ({}))
```
```
.attrs(props => {
  return {};
})
```
```
.attrs(function(props) {
  return {};
})
```